### PR TITLE
fix documentation for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ SLS_OFFLINE=1 poetry run yarn sls wsgi serve
 then
 
 ```
-AWS_PROFILE=*** SLS_OFFLINE=1 poetry run python .\solvis_graphql_api\scripts\cli.py WORKING/NSHM_v1.0.4_CompositeSolution.zip NSHM_v1.0.4 -R --ensure_table
+AWS_PROFILE=*** SLS_OFFLINE=1 poetry run python ./solvis_graphql_api/scripts/cli.py WORKING/NSHM_v1.0.4_CompositeSolution.zip NSHM_v1.0.4 -R --ensure_table
 ```
 
 ### Unit tests
@@ -60,5 +60,5 @@ AWS_PROFILE=*** SLS_OFFLINE=1 poetry run python .\solvis_graphql_api\scripts\cli
 ### Push a composite solution
 
 ```
-AWS_PROFILE=*** REGION=ap-southeast-4 DEPLOYMENT_STAGE=dev S3_BUCKET_NAME=nzshm22-solvis-graphql-api-dev poetry run python .\solvis_graphql_api\scripts\cli.py WORKING/NSHM_v1.0.4_CompositeSolution.zip NSHM_v1.0.4 -R
+AWS_PROFILE=*** REGION=ap-southeast-4 DEPLOYMENT_STAGE=dev S3_BUCKET_NAME=nzshm22-solvis-graphql-api-dev poetry run python ./solvis_graphql_api/scripts/cli.py WORKING/NSHM_v1.0.4_CompositeSolution.zip NSHM_v1.0.4 -R
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ poetry lock
 poetry shell
 ```
 
-Make sure the dynamob plugin for local tests is installed
+Make sure the dynamodb plugin for local tests is installed
 ```
 yarn sls dynamodb install
 ```
@@ -41,15 +41,15 @@ yarn sls dynamodb install
 ### Run full stack locally
 
 ```
-# npx serverless dynamodb start --stage local &\
-# npx serverless s3 start &\
+npx serverless dynamodb start --stage local &\
+npx serverless s3 start &\
 SLS_OFFLINE=1 poetry run yarn sls wsgi serve
 ```
 
 then
 
 ```
-AWS_PROFILE=*** SLS_OFFLINE=1 poetry run cli WORKING/NSHM_v1.0.4_CompositeSolution.zip NSHM_v1.0.4 -R --ensure_table
+AWS_PROFILE=*** SLS_OFFLINE=1 poetry run python .\solvis_graphql_api\scripts\cli.py WORKING/NSHM_v1.0.4_CompositeSolution.zip NSHM_v1.0.4 -R --ensure_table
 ```
 
 ### Unit tests
@@ -60,5 +60,5 @@ AWS_PROFILE=*** SLS_OFFLINE=1 poetry run cli WORKING/NSHM_v1.0.4_CompositeSoluti
 ### Push a composite solution
 
 ```
-AWS_PROFILE=*** REGION=ap-southeast-4 DEPLOYMENT_STAGE=dev S3_BUCKET_NAME=nzshm22-solvis-graphql-api-dev cli WORKING/NSHM_v1.0.4_CompositeSolution.zip NSHM_v1.0.4 -R
+AWS_PROFILE=*** REGION=ap-southeast-4 DEPLOYMENT_STAGE=dev S3_BUCKET_NAME=nzshm22-solvis-graphql-api-dev poetry run python .\solvis_graphql_api\scripts\cli.py WORKING/NSHM_v1.0.4_CompositeSolution.zip NSHM_v1.0.4 -R
 ```

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,6 +9,8 @@ configValidationMode: error
 plugins:
   - serverless-wsgi
   - serverless-plugin-warmup
+  - serverless-dynamodb
+  - serverless-s3-local
 
 package:
   individually: false


### PR DESCRIPTION
Fixes to make the stack run locally.

Calling `poetry run cli` now calls a cli script from a dependency rather than the script we want to call, so I've made the path explicit.