### PR TITLE
Phase 4 — deploy/CI/deps hardening (clean pass)

### DIFF
--- a/docs/MIGRATION_LOG.md
+++ b/docs/MIGRATION_LOG.md
@@ -126,11 +126,12 @@ Source: code exploration 2026-06-24 on `deploy-test` @ `93f6f62`. Version **0.9.
 - [x] Bugs the SDL gate can't see, **caught by the harness**: relay global-id encoding (`to_global_id`, Model C1), float opacity defaults, and the input-instance-vs-mapping default coercion (×2).
 - [x] CI already on `-uv`; `branches:` filter removed (Phase 1). Legacy suite still drives graphene (unchanged); the harness proves the Strawberry schema matches.
 
-### Phase 4 — Deploy / CI / deps
-- [ ] Validate container build + dep install path (Dockerfile vs SF requirements); image-size pass (multi-stage)
-- [ ] Yarn resolutions hygiene — validate `serverless-s3-local` + `serverless-dynamodb` plugin chain loads (`node -e "require('s3rver')"`, `yarn sls package --stage dummy`)
-- [ ] vuln audit (pip-audit) — bumps via `pyup`
-- [ ] memory watch (keep 2096 unless evidence)
+### Phase 4 — Deploy / CI / deps ✅
+- [x] Container build path: deploy is on the shared **`deploy-to-aws-uv.yml`** (uv-aware, `docker: true`) which exports `requirements.txt` from `uv.lock` → `Dockerfile` `pip install`. Local amd64 build green; **360 MB** (< the §A3 500 MB aim → no multi-stage needed); `app.handler` (Mangum) + full Strawberry schema import in-image.
+- [x] Plugin chain loads: `require('s3rver')` + `serverless-dynamodb` OK; **no `resolutions` block needed** (no fast-xml-parser/s3rver conflict here, unlike toshi-api §4.7).
+- [x] **`pip-audit` (runtime deps): no known vulnerabilities.**
+- [x] Removed dead `serverless-wsgi` npm plugin + stale `requirements_*` scripts from `package.json`; `yarn install --mode update-lockfile` then `--immutable` clean (§4.6).
+- [x] memory kept **2096 MB** (no evidence to change).
 
 ### Phase 5 — Cutover
 - [ ] Deploy to test stage; **`cli_ab_test` prod-vs-new** differential validation (the built-in harness)
@@ -208,5 +209,13 @@ Source: code exploration 2026-06-24 on `deploy-test` @ `93f6f62`. Version **0.9.
 - **mypy**: graphene-constructor `type: ignore[call-arg]` (untyped ObjectType `__init__`), None-safe `_fso_dict`, edges/normalisation narrowing — new code clean.
 - SDL parity byte-identical; **11 differential checks** + full suite **88 passed / 10 skipped**; ruff + mypy(new) clean.
 - **Next:** Phase 4 (container build/deps hardening, yarn resolutions, image size) → Phase 5 cutover (`cli_ab_test` vs live).
+
+### 2026-06-24 — Phase 4: deploy/CI/deps hardening (clean pass)
+- **Container:** amd64 `docker build` green with the migrated deps (strawberry/fastapi/mangum in, pynamodb out); image **360 MB** (geo stack: matplotlib/geopandas/pyproj/shapely/solvis) — under the 500 MB aim, so single-stage is fine. `docker run … import solvis_graphql_api.app` → Mangum handler + full schema load in-image. Dep path: shared `deploy-to-aws-uv.yml` exports `requirements.txt` from `uv.lock` before the build (the local build mirrors it).
+- **Plugins / §4.7:** `require('s3rver')` + `serverless-dynamodb` load fine; **no `resolutions` needed** (solvis doesn't hit the fast-xml-parser/s3rver clash toshi-api did). `sls package --stage dummy` reaches plugin init cleanly.
+- **Vulns:** `pip-audit` on runtime deps → **none**. No `pyup` bump required.
+- **Hygiene:** dropped the dead `serverless-wsgi` npm plugin (no longer in `serverless.yml`) + stale `requirements_1/2` scripts; lockfile updated, `--immutable` clean.
+- CI already on the `-uv` test + deploy workflows. Memory stays 2096 MB.
+- **Next:** Phase 5 — deploy to test stage, run `cli_ab_test` (prod-vs-new differential), promote with a pre-staged revert, then post-healthy legacy cleanup (delete `schema/` graphene + Flask + `handler.py`, rename `strawberry_schema.py` → `schema.py`).
 
 <!-- Append new dated entries above this line as the migration proceeds. -->

--- a/package.json
+++ b/package.json
@@ -6,13 +6,10 @@
     "serverless": "^4.29.0",
     "serverless-dynamodb": "^0.2.56",
     "serverless-plugin-warmup": "^8.3.0",
-    "serverless-s3-local": "^0.8.5",
-    "serverless-wsgi": "^3.1.0"
+    "serverless-s3-local": "^0.8.5"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "requirements_1": "serverless requirements clean",
-    "requirements_2": "serverless requirements cleanCache",
     "dummy_pkg": "serverless package --stage dummy",
     "deploy": "serverless deploy --stage ${STAGE}",
     "sls_doctor": "serverless doctor"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,13 +1939,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bluebird@npm:^3.7.2":
-  version: 3.7.2
-  resolution: "bluebird@npm:3.7.2"
-  checksum: 10c0/680de03adc54ff925eaa6c7bb9a47a0690e8b5de60f4792604aae8ed618c65e6b63a7893b57ca924beaf53eee69c5af4f8314148c08124c550fe1df1add897d2
-  languageName: node
-  linkType: hard
-
 "bowser@npm:^2.11.0":
   version: 2.12.1
   resolution: "bowser@npm:2.12.1"
@@ -2156,13 +2149,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"command-exists@npm:^1.2.9":
-  version: 1.2.9
-  resolution: "command-exists@npm:1.2.9"
-  checksum: 10c0/75040240062de46cd6cd43e6b3032a8b0494525c89d3962e280dde665103f8cc304a8b313a5aa541b91da2f5a9af75c5959dc3a77893a2726407a5e9a0234c16
-  languageName: node
-  linkType: hard
-
 "commander@npm:^5.0.0":
   version: 5.1.0
   resolution: "commander@npm:5.1.0"
@@ -2230,16 +2216,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d@npm:1, d@npm:^1.0.1, d@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "d@npm:1.0.2"
-  dependencies:
-    es5-ext: "npm:^0.10.64"
-    type: "npm:^2.7.2"
-  checksum: 10c0/3e6ede10cd3b77586c47da48423b62bed161bf1a48bdbcc94d87263522e22f5dfb0e678a6dba5323fdc14c5d8612b7f7eb9e7d9e37b2e2d67a7bf9f116dabe5a
-  languageName: node
-  linkType: hard
-
 "debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
@@ -2256,19 +2232,6 @@ __metadata:
   version: 1.0.1
   resolution: "deep-equal@npm:1.0.1"
   checksum: 10c0/bef838ef9824e124d10335deb9c7540bfc9f2f0eab17ad1bb870d0eee83ee4e7e6f6f892e5eebc2bd82759a76676926ad5246180097e28e57752176ff7dae888
-  languageName: node
-  linkType: hard
-
-"deferred@npm:^0.7.11":
-  version: 0.7.11
-  resolution: "deferred@npm:0.7.11"
-  dependencies:
-    d: "npm:^1.0.1"
-    es5-ext: "npm:^0.10.50"
-    event-emitter: "npm:^0.3.5"
-    next-tick: "npm:^1.0.0"
-    timers-ext: "npm:^0.1.7"
-  checksum: 10c0/087b944f2c28d431ce71999c1a7402f2cf3c114a774843d15dd93fa112cd08ec3daa76f456208796e785086c5bad8a61156329f9a9d40f0eedbbc3d478e78605
   languageName: node
   linkType: hard
 
@@ -2411,51 +2374,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es5-ext@npm:^0.10.35, es5-ext@npm:^0.10.46, es5-ext@npm:^0.10.50, es5-ext@npm:^0.10.62, es5-ext@npm:^0.10.64, es5-ext@npm:~0.10.14, es5-ext@npm:~0.10.2":
-  version: 0.10.64
-  resolution: "es5-ext@npm:0.10.64"
-  dependencies:
-    es6-iterator: "npm:^2.0.3"
-    es6-symbol: "npm:^3.1.3"
-    esniff: "npm:^2.0.1"
-    next-tick: "npm:^1.1.0"
-  checksum: 10c0/4459b6ae216f3c615db086e02437bdfde851515a101577fd61b19f9b3c1ad924bab4d197981eb7f0ccb915f643f2fc10ff76b97a680e96cbb572d15a27acd9a3
-  languageName: node
-  linkType: hard
-
-"es6-iterator@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "es6-iterator@npm:2.0.3"
-  dependencies:
-    d: "npm:1"
-    es5-ext: "npm:^0.10.35"
-    es6-symbol: "npm:^3.1.1"
-  checksum: 10c0/91f20b799dba28fb05bf623c31857fc1524a0f1c444903beccaf8929ad196c8c9ded233e5ac7214fc63a92b3f25b64b7f2737fcca8b1f92d2d96cf3ac902f5d8
-  languageName: node
-  linkType: hard
-
-"es6-symbol@npm:^3.1.1, es6-symbol@npm:^3.1.3":
-  version: 3.1.4
-  resolution: "es6-symbol@npm:3.1.4"
-  dependencies:
-    d: "npm:^1.0.2"
-    ext: "npm:^1.7.0"
-  checksum: 10c0/777bf3388db5d7919e09a0fd175aa5b8a62385b17cb2227b7a137680cba62b4d9f6193319a102642aa23d5840d38a62e4784f19cfa5be4a2210a3f0e9b23d15d
-  languageName: node
-  linkType: hard
-
-"es6-weak-map@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "es6-weak-map@npm:2.0.3"
-  dependencies:
-    d: "npm:1"
-    es5-ext: "npm:^0.10.46"
-    es6-iterator: "npm:^2.0.3"
-    es6-symbol: "npm:^3.1.1"
-  checksum: 10c0/460932be9542473dbbddd183e21c15a66cfec1b2c17dae2b514e190d6fb2896b7eb683783d4b36da036609d2e1c93d2815f21b374dfccaf02a8978694c2f7b67
-  languageName: node
-  linkType: hard
-
 "escape-html@npm:^1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
@@ -2467,28 +2385,6 @@ __metadata:
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
-  languageName: node
-  linkType: hard
-
-"esniff@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "esniff@npm:2.0.1"
-  dependencies:
-    d: "npm:^1.0.1"
-    es5-ext: "npm:^0.10.62"
-    event-emitter: "npm:^0.3.5"
-    type: "npm:^2.7.2"
-  checksum: 10c0/7efd8d44ac20e5db8cb0ca77eb65eca60628b2d0f3a1030bcb05e71cc40e6e2935c47b87dba3c733db12925aa5b897f8e0e7a567a2c274206f184da676ea2e65
-  languageName: node
-  linkType: hard
-
-"event-emitter@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "event-emitter@npm:0.3.5"
-  dependencies:
-    d: "npm:1"
-    es5-ext: "npm:~0.10.14"
-  checksum: 10c0/75082fa8ffb3929766d0f0a063bfd6046bd2a80bea2666ebaa0cfd6f4a9116be6647c15667bea77222afc12f5b4071b68d393cf39fdaa0e8e81eda006160aff0
   languageName: node
   linkType: hard
 
@@ -2506,15 +2402,6 @@ __metadata:
     signal-exit: "npm:^4.1.0"
     strip-final-newline: "npm:^3.0.0"
   checksum: 10c0/2c52d8775f5bf103ce8eec9c7ab3059909ba350a5164744e9947ed14a53f51687c040a250bda833f906d1283aa8803975b84e6c8f7a7c42f99dc8ef80250d1af
-  languageName: node
-  linkType: hard
-
-"ext@npm:^1.4.0, ext@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "ext@npm:1.7.0"
-  dependencies:
-    type: "npm:^2.7.2"
-  checksum: 10c0/a8e5f34e12214e9eee3a4af3b5c9d05ba048f28996450975b369fc86e5d0ef13b6df0615f892f5396a9c65d616213c25ec5b0ad17ef42eac4a500512a19da6c7
   languageName: node
   linkType: hard
 
@@ -2629,22 +2516,6 @@ __metadata:
   version: 1.0.0
   resolution: "fs.realpath@npm:1.0.0"
   checksum: 10c0/444cf1291d997165dfd4c0d58b69f0e4782bfd9149fd72faa4fe299e68e0e93d6db941660b37dd29153bf7186672ececa3b50b7e7249477b03fdf850f287c948
-  languageName: node
-  linkType: hard
-
-"fs2@npm:^0.3.9":
-  version: 0.3.16
-  resolution: "fs2@npm:0.3.16"
-  dependencies:
-    d: "npm:^1.0.2"
-    deferred: "npm:^0.7.11"
-    es5-ext: "npm:^0.10.64"
-    event-emitter: "npm:^0.3.5"
-    ext: "npm:^1.7.0"
-    ignore: "npm:^5.3.2"
-    memoizee: "npm:^0.4.17"
-    type: "npm:^2.7.3"
-  checksum: 10c0/9faaf5568aa6b5176dfa850c1da0dad09e96e8d1eb91b19a25c5ad7c1d411660feab65d603e7435b222914f0397be5c1a57a5be7f80b3c498515bf70da1939c5
   languageName: node
   linkType: hard
 
@@ -2819,13 +2690,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.3.2":
-  version: 5.3.2
-  resolution: "ignore@npm:5.3.2"
-  checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
-  languageName: node
-  linkType: hard
-
 "immediate@npm:~3.0.5":
   version: 3.0.6
   resolution: "immediate@npm:3.0.6"
@@ -2903,13 +2767,6 @@ __metadata:
   bin:
     is-inside-container: cli.js
   checksum: 10c0/a8efb0e84f6197e6ff5c64c52890fa9acb49b7b74fed4da7c95383965da6f0fa592b4dbd5e38a79f87fc108196937acdbcd758fcefc9b140e479b39ce1fcd1cd
-  languageName: node
-  linkType: hard
-
-"is-promise@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "is-promise@npm:2.2.2"
-  checksum: 10c0/2dba959812380e45b3df0fb12e7cb4d4528c989c7abb03ececb1d1fd6ab1cbfee956ca9daa587b9db1d8ac3c1e5738cf217bdb3dfd99df8c691be4c00ae09069
   languageName: node
   linkType: hard
 
@@ -3148,7 +3005,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21, lodash@npm:^4.17.5":
+"lodash@npm:^4.17.5":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -3183,15 +3040,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-queue@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "lru-queue@npm:0.1.0"
-  dependencies:
-    es5-ext: "npm:~0.10.2"
-  checksum: 10c0/83517032b46843601c4528be65e8aaf85f5a7860a9cfa3e4f2b5591da436e7cd748d95b450c91434c4ffb75d3ae4c069ddbdd9f71ada56a99a00c03088c51b4d
-  languageName: node
-  linkType: hard
-
 "luxon@npm:^3.2.1, luxon@npm:^3.5.0":
   version: 3.7.2
   resolution: "luxon@npm:3.7.2"
@@ -3210,22 +3058,6 @@ __metadata:
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
   checksum: 10c0/d160f31246907e79fed398470285f21bafb45a62869dc469b1c8877f3f064f5eabc4bcc122f9479b8b605bc5c76187d7871cf84c4ee3ecd3e487da1993279928
-  languageName: node
-  linkType: hard
-
-"memoizee@npm:^0.4.14, memoizee@npm:^0.4.17":
-  version: 0.4.17
-  resolution: "memoizee@npm:0.4.17"
-  dependencies:
-    d: "npm:^1.0.2"
-    es5-ext: "npm:^0.10.64"
-    es6-weak-map: "npm:^2.0.3"
-    event-emitter: "npm:^0.3.5"
-    is-promise: "npm:^2.2.2"
-    lru-queue: "npm:^0.1.0"
-    next-tick: "npm:^1.1.0"
-    timers-ext: "npm:^0.1.7"
-  checksum: 10c0/19821d055f0f641e79b718f91d6d89a6c92840643234a6f4e91d42aa330e8406f06c47d3828931e177c38830aa9b959710e5b7f0013be452af46d0f9eae4baf4
   languageName: node
   linkType: hard
 
@@ -3346,13 +3178,6 @@ __metadata:
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: 10c0/3ec9fd413e7bf071c937ae60d572bc67155262068ed522cf4b3be5edbe6ddf67d095ec03a3a14ebf8fc8e95f8e1d61be4869db0dbb0de696f6b837358bd43fc2
-  languageName: node
-  linkType: hard
-
-"next-tick@npm:^1.0.0, next-tick@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "next-tick@npm:1.1.0"
-  checksum: 10c0/3ba80dd805fcb336b4f52e010992f3e6175869c8d88bf4ff0a81d5d66e6049f89993463b28211613e58a6b7fe93ff5ccbba0da18d4fa574b96289e8f0b577f28
   languageName: node
   linkType: hard
 
@@ -3513,18 +3338,6 @@ __metadata:
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
   checksum: 10c0/bec089239487833d46b59d80327a1605e1c5287eaad770a291add7f45fda1bb5e28b38e0e061add0a1d0ee0984788ce74fa394d345eed1c420cacf392c554367
-  languageName: node
-  linkType: hard
-
-"process-utils@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "process-utils@npm:4.0.0"
-  dependencies:
-    ext: "npm:^1.4.0"
-    fs2: "npm:^0.3.9"
-    memoizee: "npm:^0.4.14"
-    type: "npm:^2.1.0"
-  checksum: 10c0/31ff8ff7d62bfd8d768c917f1a523757188062f6fa1762fa44f815bf1adcde5b03d547f13d3dc40f63682fdfeccdccd958c1451701fd468ff24313ed301930d5
   languageName: node
   linkType: hard
 
@@ -3748,19 +3561,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serverless-wsgi@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "serverless-wsgi@npm:3.1.0"
-  dependencies:
-    bluebird: "npm:^3.7.2"
-    command-exists: "npm:^1.2.9"
-    fs-extra: "npm:^11.2.0"
-    lodash: "npm:^4.17.21"
-    process-utils: "npm:^4.0.0"
-  checksum: 10c0/e2bccb97a02a6459b0d041d8032e7f9de0de521e3c2111452b21e53862ca3fca2ac28d4b3c6f3103025b6e98aea36ab312b22680c39c39c30f15188b8ec8be9f
-  languageName: node
-  linkType: hard
-
 "serverless@npm:^4.29.0":
   version: 4.29.0
   resolution: "serverless@npm:4.29.0"
@@ -3834,7 +3634,6 @@ __metadata:
     serverless-dynamodb: "npm:^0.2.56"
     serverless-plugin-warmup: "npm:^8.3.0"
     serverless-s3-local: "npm:^0.8.5"
-    serverless-wsgi: "npm:^3.1.0"
   languageName: unknown
   linkType: soft
 
@@ -3980,16 +3779,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timers-ext@npm:^0.1.7":
-  version: 0.1.8
-  resolution: "timers-ext@npm:0.1.8"
-  dependencies:
-    es5-ext: "npm:^0.10.64"
-    next-tick: "npm:^1.1.0"
-  checksum: 10c0/d0222d0c171d08df69e51462e3fa2085744d13f8ac82b27597db05db1a09bc4244e03ea3cebe89ba279fd43f45daa39156acbe5b6ae5a9b9d62d300543312533
-  languageName: node
-  linkType: hard
-
 "toidentifier@npm:1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
@@ -4053,13 +3842,6 @@ __metadata:
     media-typer: "npm:0.3.0"
     mime-types: "npm:~2.1.24"
   checksum: 10c0/a23daeb538591b7efbd61ecf06b6feb2501b683ffdc9a19c74ef5baba362b4347e42f1b4ed81f5882a8c96a3bfff7f93ce3ffaf0cbbc879b532b04c97a55db9d
-  languageName: node
-  linkType: hard
-
-"type@npm:^2.1.0, type@npm:^2.7.2, type@npm:^2.7.3":
-  version: 2.7.3
-  resolution: "type@npm:2.7.3"
-  checksum: 10c0/dec6902c2c42fcb86e3adf8cdabdf80e5ef9de280872b5fd547351e9cca2fe58dd2aa6d2547626ddff174145db272f62d95c7aa7038e27c11315657d781a688d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Stacked migration — PR 6 of N.** Base = `migrate/strawberry-p3` (Phase 3, #92).
Epic: GNS-Science/nshm-toshi-api#359 · Tracking: #86 · Log: `docs/MIGRATION_LOG.md`

The deploy-layer validation. Came back clean — the migration's deps/container/CI are healthy.

## Findings

- **Container:** amd64 `docker build` green with the migrated deps (strawberry/fastapi/mangum in, pynamodb out). Image **360 MB** (geo stack) — under the §A3 500 MB aim, so single-stage stays. `docker run … import solvis_graphql_api.app` → Mangum handler + full Strawberry schema load **in-image**. Dep path: the shared `deploy-to-aws-uv.yml` exports `requirements.txt` from `uv.lock` before the build (local build mirrors it).
- **Plugins (§4.7):** `s3rver` + `serverless-dynamodb` load fine; **no `resolutions` block needed** — solvis doesn't hit the fast-xml-parser/s3rver clash toshi-api did.
- **Vulns:** `pip-audit` on runtime deps → **none**. No `pyup` bump.
- **Memory:** stays **2096 MB** (no evidence to change).

## Changes

- Removed the dead `serverless-wsgi` npm plugin (no longer in `serverless.yml`) + stale `requirements_1/2` scripts from `package.json`; `yarn install --mode update-lockfile` then `--immutable` clean (§4.6).

## Verification

- [x] amd64 build + in-image handler/schema import
- [x] `pip-audit` clean; plugin chain loads; `yarn install --immutable` clean
- [x] CI already on the `-uv` test + deploy workflows